### PR TITLE
bugfix: Ensure lock tattle isn't sensitive to old errno values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ valgrind: $(BIN_DIR)/test
 		echo "\e[01;31mError: valgrind is not installed\e[0m";  \
 		exit 1;                                                 \
 	}
-	RUNNING_ON_VALGRIND=1 valgrind --tool=memcheck --leak-check=yes ./bin/test
+	RUNNING_ON_VALGRIND=1 valgrind --tool=memcheck --leak-check=yes --quiet ./bin/test
 
 cov: $(BIN_DIR)/test
 	$(BIN_DIR)/test

--- a/src/pmparser.c
+++ b/src/pmparser.c
@@ -33,6 +33,8 @@ procmaps_iterator* pmparser_parse(int pid){
 	procmaps_struct* current_node=list_maps;
 	char addr1[20],addr2[20], perm[8], offset[20], dev[10],inode[30],pathname[PATH_MAX];
 	while( !feof(file) ){
+		// Clear errno so we can test its value correctly after fgets.
+		errno = 0;
 		if (fgets(buf,PROCMAPS_LINE_MAX_LENGTH,file) == NULL){
 			if (errno == EAGAIN) {
 				continue;

--- a/src/pmparser.h
+++ b/src/pmparser.h
@@ -24,6 +24,10 @@ implied warranty.
 #include <errno.h>
 #include <linux/limits.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //maximum line length in a procmaps file
 #define PROCMAPS_LINE_MAX_LENGTH  (PATH_MAX + 100) 
 /**
@@ -92,8 +96,8 @@ void _pmparser_split_line(char*buf,char*addr1,char*addr2,char*perm, char* offset
  */
 void pmparser_print(procmaps_struct* map,int order);
 
-
-
-
+#ifdef __cplusplus
+}  // extern C
+#endif
 
 #endif

--- a/src/test/test_pmparser.cpp
+++ b/src/test/test_pmparser.cpp
@@ -1,0 +1,15 @@
+#include "src/pmparser.h"
+
+#include <doctest.h>
+#include <cerrno>
+
+#include "src/test_util.hpp"
+
+TEST_CASE("pmparser] errno robustness") {
+  // Set errno going in to the function.
+  // Ensure that we still get a valid pmparse.
+  errno = ENOENT;
+  auto parser = pmparser_parse(-1);
+  REQUIRE_NE(parser, static_cast<procmaps_iterator*>(NULL));
+  pmparser_free(parser);
+}


### PR DESCRIPTION
This fixes an error where A0 lock tattles would suddenly seemingly fail to resolve the memory map file:

```
Warning: [Unknown] A0 Transport lock held for 155.999ms. Above threshold of 100.000ms
pmparser : fgets failed, (2){0} No such file or directory
```
This was due to errno being set in the calling context already and misidentified inside the a0 lock timing code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thirdwave-ai/alephzero-private/2)
<!-- Reviewable:end -->
