### PR TITLE
Make a0::Packet(a0::PacketView) constructors explicit

### DIFF
--- a/include/a0/alephzero.hpp
+++ b/include/a0/alephzero.hpp
@@ -135,11 +135,13 @@ struct Packet : details::CppWrap<a0_packet_t> {
   Packet(std::vector<std::pair<std::string, std::string>> headers,
          std::string payload);
 
+  /// Keep these explicit to avoid invisible copies.
+  ///
   /// Create a deep copy of the given PacketView.
-  Packet(const PacketView&);
+  explicit Packet(const PacketView&);
   /// Create a deep copy of the given PacketView.
-  Packet(PacketView&&);
-  Packet(a0_packet_t);
+  explicit Packet(PacketView&&);
+  explicit Packet(a0_packet_t);
 
   /// Packet unique identifier.
   std::string_view id() const;

--- a/src/test/test_cpp.cpp
+++ b/src/test/test_cpp.cpp
@@ -122,7 +122,7 @@ TEST_CASE_FIXTURE(CppPubsubFixture, "cpp] pkt") {
   REQUIRE(pkt.payload() == pkt_view.payload());
   REQUIRE(pkt.payload().data() == pkt_view.payload().data());
 
-  a0::Packet pkt2 = pkt_view;
+  a0::Packet pkt2 = a0::Packet(pkt_view);
   REQUIRE(pkt2.id() == pkt_view.id());
   REQUIRE(pkt.id() == pkt2.id());
   REQUIRE(pkt.headers() == pkt2.headers());


### PR DESCRIPTION
I tested this against the thirdwave tree and the integration PR is only a few lines long.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thirdwave-ai/alephzero-private/3)
<!-- Reviewable:end -->
